### PR TITLE
[Feat] 메인 기능 구현

### DIFF
--- a/loleye/loleye.xcodeproj/project.pbxproj
+++ b/loleye/loleye.xcodeproj/project.pbxproj
@@ -58,6 +58,7 @@
 		907F55A22D05DEA200B6E538 /* UserDataStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 907F55A12D05DE9900B6E538 /* UserDataStorage.swift */; };
 		907F55A42D05E99900B6E538 /* PostSummonerRefreshUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 907F55A32D05E99300B6E538 /* PostSummonerRefreshUseCase.swift */; };
 		907F55A62D05E9CC00B6E538 /* PostSummonerRefreshResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 907F55A52D05E9C700B6E538 /* PostSummonerRefreshResponse.swift */; };
+		907F55AB2D0F25BE00B6E538 /* SettingsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 907F55AA2D0F25BC00B6E538 /* SettingsViewModel.swift */; };
 		90F6B9EF2CCC12D7001FA67B /* LoginView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90F6B9EE2CCC12D7001FA67B /* LoginView.swift */; };
 		90F6B9F12CCC12E8001FA67B /* LoginViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90F6B9F02CCC12E8001FA67B /* LoginViewController.swift */; };
 		90F6B9F32CCC1313001FA67B /* Strings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90F6B9F22CCC1313001FA67B /* Strings.swift */; };
@@ -188,6 +189,7 @@
 		907F55A12D05DE9900B6E538 /* UserDataStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDataStorage.swift; sourceTree = "<group>"; };
 		907F55A32D05E99300B6E538 /* PostSummonerRefreshUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostSummonerRefreshUseCase.swift; sourceTree = "<group>"; };
 		907F55A52D05E9C700B6E538 /* PostSummonerRefreshResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostSummonerRefreshResponse.swift; sourceTree = "<group>"; };
+		907F55AA2D0F25BC00B6E538 /* SettingsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsViewModel.swift; sourceTree = "<group>"; };
 		90F6B9EE2CCC12D7001FA67B /* LoginView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginView.swift; sourceTree = "<group>"; };
 		90F6B9F02CCC12E8001FA67B /* LoginViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginViewController.swift; sourceTree = "<group>"; };
 		90F6B9F22CCC1313001FA67B /* Strings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Strings.swift; sourceTree = "<group>"; };
@@ -558,6 +560,7 @@
 		9008942F2CCAF7EC0000B6FE /* Settings */ = {
 			isa = PBXGroup;
 			children = (
+				907F55A92D0F25B600B6E538 /* ViewModels */,
 				900894302CCAF8040000B6FE /* Views */,
 				90F6BA332CCECCAD001FA67B /* SettingsViewController.swift */,
 			);
@@ -702,6 +705,14 @@
 				907F559F2D05DE4600B6E538 /* UserDefaultsData.swift */,
 			);
 			path = UserData;
+			sourceTree = "<group>";
+		};
+		907F55A92D0F25B600B6E538 /* ViewModels */ = {
+			isa = PBXGroup;
+			children = (
+				907F55AA2D0F25BC00B6E538 /* SettingsViewModel.swift */,
+			);
+			path = ViewModels;
 			sourceTree = "<group>";
 		};
 		90F6B9ED2CCC12CD001FA67B /* Login */ = {
@@ -1032,6 +1043,7 @@
 				907F558C2D01E3A400B6E538 /* SummonerSearchViewModel.swift in Sources */,
 				9008942B2CCAF3C30000B6FE /* MainTabBarController.swift in Sources */,
 				90FF79052CE5C57D002FEF96 /* SummonerRepositoryProtocol.swift in Sources */,
+				907F55AB2D0F25BE00B6E538 /* SettingsViewModel.swift in Sources */,
 				907F559B2D05D7E500B6E538 /* PutSummonerResponse.swift in Sources */,
 				900893E22CCAD0C60000B6FE /* AppDelegate.swift in Sources */,
 				90F6BA6F2CD2A91C001FA67B /* ControlTarget.swift in Sources */,

--- a/loleye/loleye.xcodeproj/project.pbxproj
+++ b/loleye/loleye.xcodeproj/project.pbxproj
@@ -58,6 +58,7 @@
 		907F55A22D05DEA200B6E538 /* UserDataStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 907F55A12D05DE9900B6E538 /* UserDataStorage.swift */; };
 		907F55A42D05E99900B6E538 /* PostSummonerRefreshUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 907F55A32D05E99300B6E538 /* PostSummonerRefreshUseCase.swift */; };
 		907F55A62D05E9CC00B6E538 /* PostSummonerRefreshResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 907F55A52D05E9C700B6E538 /* PostSummonerRefreshResponse.swift */; };
+		907F55A82D073FAA00B6E538 /* SettingsCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 907F55A72D073FA800B6E538 /* SettingsCell.swift */; };
 		90F6B9EF2CCC12D7001FA67B /* LoginView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90F6B9EE2CCC12D7001FA67B /* LoginView.swift */; };
 		90F6B9F12CCC12E8001FA67B /* LoginViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90F6B9F02CCC12E8001FA67B /* LoginViewController.swift */; };
 		90F6B9F32CCC1313001FA67B /* Strings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90F6B9F22CCC1313001FA67B /* Strings.swift */; };
@@ -188,6 +189,7 @@
 		907F55A12D05DE9900B6E538 /* UserDataStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDataStorage.swift; sourceTree = "<group>"; };
 		907F55A32D05E99300B6E538 /* PostSummonerRefreshUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostSummonerRefreshUseCase.swift; sourceTree = "<group>"; };
 		907F55A52D05E9C700B6E538 /* PostSummonerRefreshResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostSummonerRefreshResponse.swift; sourceTree = "<group>"; };
+		907F55A72D073FA800B6E538 /* SettingsCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsCell.swift; sourceTree = "<group>"; };
 		90F6B9EE2CCC12D7001FA67B /* LoginView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginView.swift; sourceTree = "<group>"; };
 		90F6B9F02CCC12E8001FA67B /* LoginViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginViewController.swift; sourceTree = "<group>"; };
 		90F6B9F22CCC1313001FA67B /* Strings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Strings.swift; sourceTree = "<group>"; };
@@ -567,6 +569,7 @@
 		900894302CCAF8040000B6FE /* Views */ = {
 			isa = PBXGroup;
 			children = (
+				907F55A72D073FA800B6E538 /* SettingsCell.swift */,
 				90F6BA312CCECC9D001FA67B /* SettingsView.swift */,
 			);
 			path = Views;
@@ -1031,6 +1034,7 @@
 				90F6BA762CD2BE62001FA67B /* RankTierCell.swift in Sources */,
 				907F558C2D01E3A400B6E538 /* SummonerSearchViewModel.swift in Sources */,
 				9008942B2CCAF3C30000B6FE /* MainTabBarController.swift in Sources */,
+				907F55A82D073FAA00B6E538 /* SettingsCell.swift in Sources */,
 				90FF79052CE5C57D002FEF96 /* SummonerRepositoryProtocol.swift in Sources */,
 				907F559B2D05D7E500B6E538 /* PutSummonerResponse.swift in Sources */,
 				900893E22CCAD0C60000B6FE /* AppDelegate.swift in Sources */,

--- a/loleye/loleye.xcodeproj/project.pbxproj
+++ b/loleye/loleye.xcodeproj/project.pbxproj
@@ -27,8 +27,8 @@
 		907F554C2CF612CF00B6E538 /* KeychainServiceProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 907F554B2CF612C500B6E538 /* KeychainServiceProtocol.swift */; };
 		907F554F2CF6132300B6E538 /* KeychainError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 907F554E2CF6132100B6E538 /* KeychainError.swift */; };
 		907F55512CF6133200B6E538 /* KeychainKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 907F55502CF6132E00B6E538 /* KeychainKey.swift */; };
-		907F55552CF613BA00B6E538 /* AppleLoginUsecase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 907F55542CF613B500B6E538 /* AppleLoginUsecase.swift */; };
-		907F55572CF613C000B6E538 /* KakaoLoginUsecase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 907F55562CF613BD00B6E538 /* KakaoLoginUsecase.swift */; };
+		907F55552CF613BA00B6E538 /* AppleLoginService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 907F55542CF613B500B6E538 /* AppleLoginService.swift */; };
+		907F55572CF613C000B6E538 /* KakaoLoginService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 907F55562CF613BD00B6E538 /* KakaoLoginService.swift */; };
 		907F555A2CF613E300B6E538 /* OAuthError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 907F55592CF613E000B6E538 /* OAuthError.swift */; };
 		907F555F2CF6153700B6E538 /* KakaoSDKAuth in Frameworks */ = {isa = PBXBuildFile; productRef = 907F555E2CF6153700B6E538 /* KakaoSDKAuth */; };
 		907F55632CF61A6F00B6E538 /* OAuthProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 907F55622CF61A6C00B6E538 /* OAuthProvider.swift */; };
@@ -37,7 +37,7 @@
 		907F55692CF61AFA00B6E538 /* OAuthLoginUseCaseProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 907F55682CF61AFA00B6E538 /* OAuthLoginUseCaseProtocol.swift */; };
 		907F556C2CF61C2B00B6E538 /* OAuthUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 907F556B2CF61C2B00B6E538 /* OAuthUseCase.swift */; };
 		907F556E2CFC96E700B6E538 /* LoginViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 907F556D2CFC96E500B6E538 /* LoginViewModel.swift */; };
-		907F55702CFC995B00B6E538 /* UseAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 907F556F2CFC995900B6E538 /* UseAPI.swift */; };
+		907F55702CFC995B00B6E538 /* UserAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 907F556F2CFC995900B6E538 /* UserAPI.swift */; };
 		907F55732CFC9A1C00B6E538 /* PostLoginResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 907F55722CFC9A0D00B6E538 /* PostLoginResponse.swift */; };
 		907F55762CFCA07200B6E538 /* PostLoginRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 907F55752CFCA06E00B6E538 /* PostLoginRequest.swift */; };
 		907F55782CFCAB0900B6E538 /* AlertViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 907F55772CFCAB0400B6E538 /* AlertViewController.swift */; };
@@ -59,6 +59,7 @@
 		907F55A42D05E99900B6E538 /* PostSummonerRefreshUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 907F55A32D05E99300B6E538 /* PostSummonerRefreshUseCase.swift */; };
 		907F55A62D05E9CC00B6E538 /* PostSummonerRefreshResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 907F55A52D05E9C700B6E538 /* PostSummonerRefreshResponse.swift */; };
 		907F55AB2D0F25BE00B6E538 /* SettingsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 907F55AA2D0F25BC00B6E538 /* SettingsViewModel.swift */; };
+		907F55AE2D0F2A9100B6E538 /* PostDeleteUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 907F55AD2D0F2A8400B6E538 /* PostDeleteUseCase.swift */; };
 		90F6B9EF2CCC12D7001FA67B /* LoginView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90F6B9EE2CCC12D7001FA67B /* LoginView.swift */; };
 		90F6B9F12CCC12E8001FA67B /* LoginViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90F6B9F02CCC12E8001FA67B /* LoginViewController.swift */; };
 		90F6B9F32CCC1313001FA67B /* Strings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90F6B9F22CCC1313001FA67B /* Strings.swift */; };
@@ -159,8 +160,8 @@
 		907F554B2CF612C500B6E538 /* KeychainServiceProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainServiceProtocol.swift; sourceTree = "<group>"; };
 		907F554E2CF6132100B6E538 /* KeychainError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainError.swift; sourceTree = "<group>"; };
 		907F55502CF6132E00B6E538 /* KeychainKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainKey.swift; sourceTree = "<group>"; };
-		907F55542CF613B500B6E538 /* AppleLoginUsecase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleLoginUsecase.swift; sourceTree = "<group>"; };
-		907F55562CF613BD00B6E538 /* KakaoLoginUsecase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KakaoLoginUsecase.swift; sourceTree = "<group>"; };
+		907F55542CF613B500B6E538 /* AppleLoginService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleLoginService.swift; sourceTree = "<group>"; };
+		907F55562CF613BD00B6E538 /* KakaoLoginService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KakaoLoginService.swift; sourceTree = "<group>"; };
 		907F55592CF613E000B6E538 /* OAuthError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OAuthError.swift; sourceTree = "<group>"; };
 		907F55622CF61A6C00B6E538 /* OAuthProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OAuthProvider.swift; sourceTree = "<group>"; };
 		907F55642CF61AA400B6E538 /* OAuthResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OAuthResult.swift; sourceTree = "<group>"; };
@@ -168,7 +169,7 @@
 		907F55682CF61AFA00B6E538 /* OAuthLoginUseCaseProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OAuthLoginUseCaseProtocol.swift; sourceTree = "<group>"; };
 		907F556B2CF61C2B00B6E538 /* OAuthUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OAuthUseCase.swift; sourceTree = "<group>"; };
 		907F556D2CFC96E500B6E538 /* LoginViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginViewModel.swift; sourceTree = "<group>"; };
-		907F556F2CFC995900B6E538 /* UseAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UseAPI.swift; sourceTree = "<group>"; };
+		907F556F2CFC995900B6E538 /* UserAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserAPI.swift; sourceTree = "<group>"; };
 		907F55722CFC9A0D00B6E538 /* PostLoginResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostLoginResponse.swift; sourceTree = "<group>"; };
 		907F55742CFC9C7400B6E538 /* loleye.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = loleye.entitlements; sourceTree = "<group>"; };
 		907F55752CFCA06E00B6E538 /* PostLoginRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostLoginRequest.swift; sourceTree = "<group>"; };
@@ -190,6 +191,7 @@
 		907F55A32D05E99300B6E538 /* PostSummonerRefreshUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostSummonerRefreshUseCase.swift; sourceTree = "<group>"; };
 		907F55A52D05E9C700B6E538 /* PostSummonerRefreshResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostSummonerRefreshResponse.swift; sourceTree = "<group>"; };
 		907F55AA2D0F25BC00B6E538 /* SettingsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsViewModel.swift; sourceTree = "<group>"; };
+		907F55AD2D0F2A8400B6E538 /* PostDeleteUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostDeleteUseCase.swift; sourceTree = "<group>"; };
 		90F6B9EE2CCC12D7001FA67B /* LoginView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginView.swift; sourceTree = "<group>"; };
 		90F6B9F02CCC12E8001FA67B /* LoginViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginViewController.swift; sourceTree = "<group>"; };
 		90F6B9F22CCC1313001FA67B /* Strings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Strings.swift; sourceTree = "<group>"; };
@@ -386,7 +388,7 @@
 		900893FC2CCAD37D0000B6FE /* UseCases */ = {
 			isa = PBXGroup;
 			children = (
-				907F55532CF613AE00B6E538 /* OAuth */,
+				907F55532CF613AE00B6E538 /* User */,
 				907F55522CF613A600B6E538 /* Summoner */,
 			);
 			path = UseCases;
@@ -641,14 +643,13 @@
 			path = Summoner;
 			sourceTree = "<group>";
 		};
-		907F55532CF613AE00B6E538 /* OAuth */ = {
+		907F55532CF613AE00B6E538 /* User */ = {
 			isa = PBXGroup;
 			children = (
-				907F556B2CF61C2B00B6E538 /* OAuthUseCase.swift */,
-				907F55562CF613BD00B6E538 /* KakaoLoginUsecase.swift */,
-				907F55542CF613B500B6E538 /* AppleLoginUsecase.swift */,
+				907F55AD2D0F2A8400B6E538 /* PostDeleteUseCase.swift */,
+				907F55AC2D0F2A7600B6E538 /* Login */,
 			);
-			path = OAuth;
+			path = User;
 			sourceTree = "<group>";
 		};
 		907F55582CF613D400B6E538 /* OAuth */ = {
@@ -713,6 +714,16 @@
 				907F55AA2D0F25BC00B6E538 /* SettingsViewModel.swift */,
 			);
 			path = ViewModels;
+			sourceTree = "<group>";
+		};
+		907F55AC2D0F2A7600B6E538 /* Login */ = {
+			isa = PBXGroup;
+			children = (
+				907F556B2CF61C2B00B6E538 /* OAuthUseCase.swift */,
+				907F55562CF613BD00B6E538 /* KakaoLoginService.swift */,
+				907F55542CF613B500B6E538 /* AppleLoginService.swift */,
+			);
+			path = Login;
 			sourceTree = "<group>";
 		};
 		90F6B9ED2CCC12CD001FA67B /* Login */ = {
@@ -827,7 +838,7 @@
 		90FF78EC2CE5BD8B002FEF96 /* API */ = {
 			isa = PBXGroup;
 			children = (
-				907F556F2CFC995900B6E538 /* UseAPI.swift */,
+				907F556F2CFC995900B6E538 /* UserAPI.swift */,
 				90FF78ED2CE5BDA1002FEF96 /* SummonerAPI.swift */,
 			);
 			path = API;
@@ -1016,7 +1027,7 @@
 				90F6BA212CCD6473001FA67B /* MainFlowCoordinator.swift in Sources */,
 				90FF79072CE5C5A7002FEF96 /* GetSummonerDetailUseCase.swift in Sources */,
 				90F6BA382CCECD98001FA67B /* HomeFlowCoordinator.swift in Sources */,
-				907F55572CF613C000B6E538 /* KakaoLoginUsecase.swift in Sources */,
+				907F55572CF613C000B6E538 /* KakaoLoginService.swift in Sources */,
 				907F55A62D05E9CC00B6E538 /* PostSummonerRefreshResponse.swift in Sources */,
 				90F6BA722CD2AE85001FA67B /* SummonerProfileView.swift in Sources */,
 				90F6BA072CCD56C3001FA67B /* RelationshipViewController.swift in Sources */,
@@ -1029,6 +1040,7 @@
 				90F6BA272CCD677A001FA67B /* ControlEvent.swift in Sources */,
 				907F55A42D05E99900B6E538 /* PostSummonerRefreshUseCase.swift in Sources */,
 				90FF78F32CE5BE4F002FEF96 /* SummonerInfoEntity.swift in Sources */,
+				907F55AE2D0F2A9100B6E538 /* PostDeleteUseCase.swift in Sources */,
 				90FF78DA2CE5B822002FEF96 /* NetworkService.swift in Sources */,
 				90F6BA7C2CD4BD3E001FA67B /* TodayPlayLogView.swift in Sources */,
 				90F6BA782CD2C5C4001FA67B /* TodayView.swift in Sources */,
@@ -1038,7 +1050,7 @@
 				90FF78D62CE5B80D002FEF96 /* TargetType.swift in Sources */,
 				90F6BA092CCD5A68001FA67B /* RelationshipView.swift in Sources */,
 				90F6B9EF2CCC12D7001FA67B /* LoginView.swift in Sources */,
-				907F55702CFC995B00B6E538 /* UseAPI.swift in Sources */,
+				907F55702CFC995B00B6E538 /* UserAPI.swift in Sources */,
 				90F6BA762CD2BE62001FA67B /* RankTierCell.swift in Sources */,
 				907F558C2D01E3A400B6E538 /* SummonerSearchViewModel.swift in Sources */,
 				9008942B2CCAF3C30000B6FE /* MainTabBarController.swift in Sources */,
@@ -1071,7 +1083,7 @@
 				90F6BA0E2CCD5B74001FA67B /* Relationship.swift in Sources */,
 				90F6BA2B2CCD67B7001FA67B /* UIButton+Combine.swift in Sources */,
 				90F6B9F32CCC1313001FA67B /* Strings.swift in Sources */,
-				907F55552CF613BA00B6E538 /* AppleLoginUsecase.swift in Sources */,
+				907F55552CF613BA00B6E538 /* AppleLoginService.swift in Sources */,
 				90F6BA3E2CCECE2C001FA67B /* SettingsDIContainer.swift in Sources */,
 				90F6BA842CD92925001FA67B /* RankTierCellViewModel.swift in Sources */,
 				90FF78FA2CE5BE6F002FEF96 /* SummonerDetail.swift in Sources */,

--- a/loleye/loleye.xcodeproj/project.pbxproj
+++ b/loleye/loleye.xcodeproj/project.pbxproj
@@ -58,7 +58,6 @@
 		907F55A22D05DEA200B6E538 /* UserDataStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 907F55A12D05DE9900B6E538 /* UserDataStorage.swift */; };
 		907F55A42D05E99900B6E538 /* PostSummonerRefreshUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 907F55A32D05E99300B6E538 /* PostSummonerRefreshUseCase.swift */; };
 		907F55A62D05E9CC00B6E538 /* PostSummonerRefreshResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 907F55A52D05E9C700B6E538 /* PostSummonerRefreshResponse.swift */; };
-		907F55A82D073FAA00B6E538 /* SettingsCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 907F55A72D073FA800B6E538 /* SettingsCell.swift */; };
 		90F6B9EF2CCC12D7001FA67B /* LoginView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90F6B9EE2CCC12D7001FA67B /* LoginView.swift */; };
 		90F6B9F12CCC12E8001FA67B /* LoginViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90F6B9F02CCC12E8001FA67B /* LoginViewController.swift */; };
 		90F6B9F32CCC1313001FA67B /* Strings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90F6B9F22CCC1313001FA67B /* Strings.swift */; };
@@ -189,7 +188,6 @@
 		907F55A12D05DE9900B6E538 /* UserDataStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDataStorage.swift; sourceTree = "<group>"; };
 		907F55A32D05E99300B6E538 /* PostSummonerRefreshUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostSummonerRefreshUseCase.swift; sourceTree = "<group>"; };
 		907F55A52D05E9C700B6E538 /* PostSummonerRefreshResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostSummonerRefreshResponse.swift; sourceTree = "<group>"; };
-		907F55A72D073FA800B6E538 /* SettingsCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsCell.swift; sourceTree = "<group>"; };
 		90F6B9EE2CCC12D7001FA67B /* LoginView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginView.swift; sourceTree = "<group>"; };
 		90F6B9F02CCC12E8001FA67B /* LoginViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginViewController.swift; sourceTree = "<group>"; };
 		90F6B9F22CCC1313001FA67B /* Strings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Strings.swift; sourceTree = "<group>"; };
@@ -569,7 +567,6 @@
 		900894302CCAF8040000B6FE /* Views */ = {
 			isa = PBXGroup;
 			children = (
-				907F55A72D073FA800B6E538 /* SettingsCell.swift */,
 				90F6BA312CCECC9D001FA67B /* SettingsView.swift */,
 			);
 			path = Views;
@@ -1034,7 +1031,6 @@
 				90F6BA762CD2BE62001FA67B /* RankTierCell.swift in Sources */,
 				907F558C2D01E3A400B6E538 /* SummonerSearchViewModel.swift in Sources */,
 				9008942B2CCAF3C30000B6FE /* MainTabBarController.swift in Sources */,
-				907F55A82D073FAA00B6E538 /* SettingsCell.swift in Sources */,
 				90FF79052CE5C57D002FEF96 /* SummonerRepositoryProtocol.swift in Sources */,
 				907F559B2D05D7E500B6E538 /* PutSummonerResponse.swift in Sources */,
 				900893E22CCAD0C60000B6FE /* AppDelegate.swift in Sources */,

--- a/loleye/loleye.xcodeproj/project.pbxproj
+++ b/loleye/loleye.xcodeproj/project.pbxproj
@@ -56,6 +56,8 @@
 		907F559B2D05D7E500B6E538 /* PutSummonerResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 907F559A2D05D7E200B6E538 /* PutSummonerResponse.swift */; };
 		907F55A02D05DE4A00B6E538 /* UserDefaultsData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 907F559F2D05DE4600B6E538 /* UserDefaultsData.swift */; };
 		907F55A22D05DEA200B6E538 /* UserDataStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 907F55A12D05DE9900B6E538 /* UserDataStorage.swift */; };
+		907F55A42D05E99900B6E538 /* PostSummonerRefreshUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 907F55A32D05E99300B6E538 /* PostSummonerRefreshUseCase.swift */; };
+		907F55A62D05E9CC00B6E538 /* PostSummonerRefreshResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 907F55A52D05E9C700B6E538 /* PostSummonerRefreshResponse.swift */; };
 		90F6B9EF2CCC12D7001FA67B /* LoginView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90F6B9EE2CCC12D7001FA67B /* LoginView.swift */; };
 		90F6B9F12CCC12E8001FA67B /* LoginViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90F6B9F02CCC12E8001FA67B /* LoginViewController.swift */; };
 		90F6B9F32CCC1313001FA67B /* Strings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90F6B9F22CCC1313001FA67B /* Strings.swift */; };
@@ -184,6 +186,8 @@
 		907F559A2D05D7E200B6E538 /* PutSummonerResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PutSummonerResponse.swift; sourceTree = "<group>"; };
 		907F559F2D05DE4600B6E538 /* UserDefaultsData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultsData.swift; sourceTree = "<group>"; };
 		907F55A12D05DE9900B6E538 /* UserDataStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDataStorage.swift; sourceTree = "<group>"; };
+		907F55A32D05E99300B6E538 /* PostSummonerRefreshUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostSummonerRefreshUseCase.swift; sourceTree = "<group>"; };
+		907F55A52D05E9C700B6E538 /* PostSummonerRefreshResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostSummonerRefreshResponse.swift; sourceTree = "<group>"; };
 		90F6B9EE2CCC12D7001FA67B /* LoginView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginView.swift; sourceTree = "<group>"; };
 		90F6B9F02CCC12E8001FA67B /* LoginViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginViewController.swift; sourceTree = "<group>"; };
 		90F6B9F22CCC1313001FA67B /* Strings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Strings.swift; sourceTree = "<group>"; };
@@ -626,6 +630,7 @@
 		907F55522CF613A600B6E538 /* Summoner */ = {
 			isa = PBXGroup;
 			children = (
+				907F55A32D05E99300B6E538 /* PostSummonerRefreshUseCase.swift */,
 				907F55962D05D63800B6E538 /* PutSummonerUseCase.swift */,
 				907F558D2D01E4A000B6E538 /* GetSummonerSearchUseCase.swift */,
 				90FF79062CE5C5A6002FEF96 /* GetSummonerDetailUseCase.swift */,
@@ -820,6 +825,7 @@
 		90FF78EF2CE5BE43002FEF96 /* Summoner */ = {
 			isa = PBXGroup;
 			children = (
+				907F55A52D05E9C700B6E538 /* PostSummonerRefreshResponse.swift */,
 				907F559A2D05D7E200B6E538 /* PutSummonerResponse.swift */,
 				907F55882D01DA5100B6E538 /* GetSummonerSearchResponse.swift */,
 				90FF78F62CE5BE5B002FEF96 /* PlayLogEntity.swift */,
@@ -1000,6 +1006,7 @@
 				90FF79072CE5C5A7002FEF96 /* GetSummonerDetailUseCase.swift in Sources */,
 				90F6BA382CCECD98001FA67B /* HomeFlowCoordinator.swift in Sources */,
 				907F55572CF613C000B6E538 /* KakaoLoginUsecase.swift in Sources */,
+				907F55A62D05E9CC00B6E538 /* PostSummonerRefreshResponse.swift in Sources */,
 				90F6BA722CD2AE85001FA67B /* SummonerProfileView.swift in Sources */,
 				90F6BA072CCD56C3001FA67B /* RelationshipViewController.swift in Sources */,
 				907F55972D05D64900B6E538 /* PutSummonerUseCase.swift in Sources */,
@@ -1009,6 +1016,7 @@
 				907F55922D01ECE300B6E538 /* UITextField+Combine.swift in Sources */,
 				900894212CCAE07E0000B6FE /* UIFont+.swift in Sources */,
 				90F6BA272CCD677A001FA67B /* ControlEvent.swift in Sources */,
+				907F55A42D05E99900B6E538 /* PostSummonerRefreshUseCase.swift in Sources */,
 				90FF78F32CE5BE4F002FEF96 /* SummonerInfoEntity.swift in Sources */,
 				90FF78DA2CE5B822002FEF96 /* NetworkService.swift in Sources */,
 				90F6BA7C2CD4BD3E001FA67B /* TodayPlayLogView.swift in Sources */,

--- a/loleye/loleye/Application/Coordinator/AppFlowCoordinator.swift
+++ b/loleye/loleye/Application/Coordinator/AppFlowCoordinator.swift
@@ -62,6 +62,7 @@ final class AppFlowCoordinator: Coordinator {
             mainDIContainer: mainDIContainer
         )
         
+        mainCoordinator.delegate = self
         store(coordinator: mainCoordinator)
         mainCoordinator.start()
     }
@@ -71,5 +72,12 @@ extension AppFlowCoordinator: OnboardingFlowCoordinatorDelegate {
     func onboardingFlowDidFinish(_ coordinator: OnboardingFlowCoordinator) {
         free(coordinator: coordinator)
         showMainFlow()
+    }
+}
+
+extension AppFlowCoordinator: MainFlowCoordinatorDelegate {
+    func mainFlowDidFinish(_ coordinator: MainFlowCoordinator) {
+        free(coordinator: coordinator)
+        showOnboardingFlow()
     }
 }

--- a/loleye/loleye/Application/Coordinator/Main/MainFlowCoordinator.swift
+++ b/loleye/loleye/Application/Coordinator/Main/MainFlowCoordinator.swift
@@ -7,8 +7,13 @@
 
 import UIKit
 
+protocol MainFlowCoordinatorDelegate: AnyObject {
+    func mainFlowDidFinish(_ coordinator: MainFlowCoordinator)
+}
+
 final class MainFlowCoordinator: Coordinator {
     var childCoordinators: [Coordinator] = []
+    weak var delegate: MainFlowCoordinatorDelegate?
     
     private let tabBarController: UITabBarController
     private let mainDIContainer: MainDIContainer
@@ -34,6 +39,7 @@ final class MainFlowCoordinator: Coordinator {
             navigationController: settingsNavigation,
             settingsDIContainer: mainDIContainer.makeSettingsDIContainer()
         )
+        settingsCoordinator.delegate = self
         
         store(coordinator: homeCoordinator)
         store(coordinator: settingsCoordinator)
@@ -53,5 +59,11 @@ final class MainFlowCoordinator: Coordinator {
         )
         
         tabBarController.setViewControllers([homeNavigation, settingsNavigation], animated: false)
+    }
+}
+
+extension MainFlowCoordinator: SettingsFlowCoordinatorDelegate {
+    func moveToLogin() {
+        delegate?.mainFlowDidFinish(self)
     }
 }

--- a/loleye/loleye/Application/Coordinator/Main/SettingsFlowCoordinator.swift
+++ b/loleye/loleye/Application/Coordinator/Main/SettingsFlowCoordinator.swift
@@ -7,8 +7,13 @@
 
 import UIKit
 
+protocol SettingsFlowCoordinatorDelegate: AnyObject {
+    func moveToLogin()
+}
+
 final class SettingsFlowCoordinator: Coordinator {
     var childCoordinators: [Coordinator] = []
+    weak var delegate: SettingsFlowCoordinatorDelegate?
     
     private let navigationController: UINavigationController
     private let settingsDIContainer: SettingsDIContainer
@@ -27,6 +32,13 @@ final class SettingsFlowCoordinator: Coordinator {
     
     private func showSettingsViewController() {
         let viewController = settingsDIContainer.makeSettingsViewController()
+        viewController.delegate = self
         navigationController.pushViewController(viewController, animated: true)
+    }
+}
+
+extension SettingsFlowCoordinator: SettingsViewControllerDelegate {
+    func moveToLogin() {
+        delegate?.moveToLogin()
     }
 }

--- a/loleye/loleye/Application/DIContainer/AppDIContainer.swift
+++ b/loleye/loleye/Application/DIContainer/AppDIContainer.swift
@@ -15,6 +15,7 @@ final class AppDIContainer {
     private let getSummonerSearchUseCase: GetSummonerSearchUseCase
     private let putSummonerUseCase: PutSummonerUseCase
     private let getSummonerDetailUseCase: GetSummonerDetailUseCase
+    private let postSummonerRefreshUseCase: PostSummonerRefreshUseCase
     
     init() {
         keychainService = KeychainService()
@@ -28,6 +29,11 @@ final class AppDIContainer {
         getSummonerSearchUseCase = GetSummonerSearchUseCase(repository: summonerRepository)
         putSummonerUseCase = PutSummonerUseCase(repository: summonerRepository)
         getSummonerDetailUseCase = GetSummonerDetailUseCase(repository: summonerRepository)
+        postSummonerRefreshUseCase = PostSummonerRefreshUseCase(repository: summonerRepository)
+        
+        if let accessToken = try? keychainService.retrieve(for: .accessToken) {
+            print("👩🏻‍💻 access token:", accessToken)
+        }
     }
     
     // MARK: - DIContainers of scenes
@@ -43,7 +49,8 @@ final class AppDIContainer {
     
     func makeMainDIContainer() -> MainDIContainer {
         let dependencies = MainDIContainer.Dependencies(
-            getSummonerDetailUseCase: getSummonerDetailUseCase
+            getSummonerDetailUseCase: getSummonerDetailUseCase,
+            postSummonerRefreshUseCase: postSummonerRefreshUseCase
         )
         return MainDIContainer(dependencies: dependencies)
     }

--- a/loleye/loleye/Application/DIContainer/AppDIContainer.swift
+++ b/loleye/loleye/Application/DIContainer/AppDIContainer.swift
@@ -49,6 +49,7 @@ final class AppDIContainer {
     
     func makeMainDIContainer() -> MainDIContainer {
         let dependencies = MainDIContainer.Dependencies(
+            keychainService: keychainService,
             getSummonerDetailUseCase: getSummonerDetailUseCase,
             postSummonerRefreshUseCase: postSummonerRefreshUseCase
         )

--- a/loleye/loleye/Application/DIContainer/AppDIContainer.swift
+++ b/loleye/loleye/Application/DIContainer/AppDIContainer.swift
@@ -16,6 +16,7 @@ final class AppDIContainer {
     private let putSummonerUseCase: PutSummonerUseCase
     private let getSummonerDetailUseCase: GetSummonerDetailUseCase
     private let postSummonerRefreshUseCase: PostSummonerRefreshUseCase
+    private let postDeleteUseCase: PostDeleteUseCase
     
     init() {
         keychainService = KeychainService()
@@ -30,6 +31,7 @@ final class AppDIContainer {
         putSummonerUseCase = PutSummonerUseCase(repository: summonerRepository)
         getSummonerDetailUseCase = GetSummonerDetailUseCase(repository: summonerRepository)
         postSummonerRefreshUseCase = PostSummonerRefreshUseCase(repository: summonerRepository)
+        postDeleteUseCase = PostDeleteUseCase(networkService: networkService)
         
         if let accessToken = try? keychainService.retrieve(for: .accessToken) {
             print("👩🏻‍💻 access token:", accessToken)
@@ -51,7 +53,8 @@ final class AppDIContainer {
         let dependencies = MainDIContainer.Dependencies(
             keychainService: keychainService,
             getSummonerDetailUseCase: getSummonerDetailUseCase,
-            postSummonerRefreshUseCase: postSummonerRefreshUseCase
+            postSummonerRefreshUseCase: postSummonerRefreshUseCase,
+            postDeleteUseCase: postDeleteUseCase
         )
         return MainDIContainer(dependencies: dependencies)
     }

--- a/loleye/loleye/Application/DIContainer/Main/HomeDIContainer.swift
+++ b/loleye/loleye/Application/DIContainer/Main/HomeDIContainer.swift
@@ -10,6 +10,7 @@ import UIKit
 final class HomeDIContainer {
     struct Dependencies {
         let getSummonerDetailUseCase: GetSummonerDetailUseCase
+        let postSummonerRefreshUseCase: PostSummonerRefreshUseCase
     }
 
     private let dependencies: Dependencies
@@ -21,7 +22,10 @@ final class HomeDIContainer {
     // MARK: - View Models
     
     func makeHomeViewModel() -> HomeViewModel {
-        return HomeViewModel(getSummonerDetailUseCase: dependencies.getSummonerDetailUseCase)
+        return HomeViewModel(
+            getSummonerDetailUseCase: dependencies.getSummonerDetailUseCase,
+            postSummonerRefreshUseCase: dependencies.postSummonerRefreshUseCase
+        )
     }
     
     // MARK: - View Controllers

--- a/loleye/loleye/Application/DIContainer/Main/MainDIContainer.swift
+++ b/loleye/loleye/Application/DIContainer/Main/MainDIContainer.swift
@@ -12,6 +12,7 @@ final class MainDIContainer {
         let keychainService: KeychainServiceProtocol
         let getSummonerDetailUseCase: GetSummonerDetailUseCase
         let postSummonerRefreshUseCase: PostSummonerRefreshUseCase
+        let postDeleteUseCase: PostDeleteUseCase
     }
 
     private let dependencies: Dependencies
@@ -32,7 +33,8 @@ final class MainDIContainer {
     
     func makeSettingsDIContainer() -> SettingsDIContainer {
         let dependencies = SettingsDIContainer.Dependencies(
-            keychainService: dependencies.keychainService
+            keychainService: dependencies.keychainService,
+            postDeleteUseCase: dependencies.postDeleteUseCase
         )
         return SettingsDIContainer(dependencies: dependencies)
     }

--- a/loleye/loleye/Application/DIContainer/Main/MainDIContainer.swift
+++ b/loleye/loleye/Application/DIContainer/Main/MainDIContainer.swift
@@ -9,6 +9,7 @@ import Foundation
 
 final class MainDIContainer {
     struct Dependencies {
+        let keychainService: KeychainServiceProtocol
         let getSummonerDetailUseCase: GetSummonerDetailUseCase
         let postSummonerRefreshUseCase: PostSummonerRefreshUseCase
     }
@@ -30,7 +31,9 @@ final class MainDIContainer {
     }
     
     func makeSettingsDIContainer() -> SettingsDIContainer {
-        let dependencies = SettingsDIContainer.Dependencies()
+        let dependencies = SettingsDIContainer.Dependencies(
+            keychainService: dependencies.keychainService
+        )
         return SettingsDIContainer(dependencies: dependencies)
     }
 }

--- a/loleye/loleye/Application/DIContainer/Main/MainDIContainer.swift
+++ b/loleye/loleye/Application/DIContainer/Main/MainDIContainer.swift
@@ -10,6 +10,7 @@ import Foundation
 final class MainDIContainer {
     struct Dependencies {
         let getSummonerDetailUseCase: GetSummonerDetailUseCase
+        let postSummonerRefreshUseCase: PostSummonerRefreshUseCase
     }
 
     private let dependencies: Dependencies
@@ -22,7 +23,8 @@ final class MainDIContainer {
     
     func makeHomeDIContainer() -> HomeDIContainer {
         let dependencies = HomeDIContainer.Dependencies(
-            getSummonerDetailUseCase: dependencies.getSummonerDetailUseCase
+            getSummonerDetailUseCase: dependencies.getSummonerDetailUseCase,
+            postSummonerRefreshUseCase: dependencies.postSummonerRefreshUseCase
         )
         return HomeDIContainer(dependencies: dependencies)
     }

--- a/loleye/loleye/Application/DIContainer/Main/SettingsDIContainer.swift
+++ b/loleye/loleye/Application/DIContainer/Main/SettingsDIContainer.swift
@@ -10,6 +10,7 @@ import UIKit
 final class SettingsDIContainer {
     struct Dependencies {
         let keychainService: KeychainServiceProtocol
+        let postDeleteUseCase: PostDeleteUseCase
     }
 
     private let dependencies: Dependencies
@@ -21,7 +22,10 @@ final class SettingsDIContainer {
     // MARK: - View Models
     
     private func makeSettingsViewModel() -> SettingsViewModel {
-        return SettingsViewModel(keychainService: dependencies.keychainService)
+        return SettingsViewModel(
+            keychainService: dependencies.keychainService,
+            postDeleteUseCase: dependencies.postDeleteUseCase
+        )
     }
     
     // MARK: - View Controllers

--- a/loleye/loleye/Application/DIContainer/Main/SettingsDIContainer.swift
+++ b/loleye/loleye/Application/DIContainer/Main/SettingsDIContainer.swift
@@ -8,7 +8,9 @@
 import UIKit
 
 final class SettingsDIContainer {
-    struct Dependencies {}
+    struct Dependencies {
+        let keychainService: KeychainServiceProtocol
+    }
 
     private let dependencies: Dependencies
 
@@ -16,9 +18,15 @@ final class SettingsDIContainer {
         self.dependencies = dependencies
     }
     
+    // MARK: - View Models
+    
+    private func makeSettingsViewModel() -> SettingsViewModel {
+        return SettingsViewModel(keychainService: dependencies.keychainService)
+    }
+    
     // MARK: - View Controllers
     
     func makeSettingsViewController() -> SettingsViewController {
-        return SettingsViewController()
+        return SettingsViewController(viewModel: makeSettingsViewModel())
     }
 }

--- a/loleye/loleye/Data/Entities/Summoner/PostSummonerRefreshResponse.swift
+++ b/loleye/loleye/Data/Entities/Summoner/PostSummonerRefreshResponse.swift
@@ -1,0 +1,12 @@
+//
+//  PostSummonerRefreshResponse.swift
+//  loleye
+//
+//  Created by 지연 on 12/8/24.
+//
+
+import Foundation
+
+struct PostSummonerRefreshResponse: Decodable {
+    let lastUpdatedWatchSummoner: String
+}

--- a/loleye/loleye/Data/Entities/Summoner/SummonerInfoEntity.swift
+++ b/loleye/loleye/Data/Entities/Summoner/SummonerInfoEntity.swift
@@ -16,6 +16,7 @@ struct SummonerInfoEntity: Decodable {
     let soloRankIconUrl: String
     let flexRankTier: String
     let flexRankIconUrl: String
+    let lastUpdatedWatchSummoner: String
     
     func toDomain() -> SummonerInfo {
         return SummonerInfo(
@@ -26,7 +27,8 @@ struct SummonerInfoEntity: Decodable {
             soloRankTier: soloRankTier,
             soloRankIconUrl: soloRankIconUrl,
             flexRankTier: flexRankTier,
-            flexRankIconUrl: flexRankIconUrl
+            flexRankIconUrl: flexRankIconUrl,
+            lastUpdatedWatchSummoner: lastUpdatedWatchSummoner
         )
     }
 }

--- a/loleye/loleye/Data/Entities/User/PostLoginRequest.swift
+++ b/loleye/loleye/Data/Entities/User/PostLoginRequest.swift
@@ -10,4 +10,5 @@ import Foundation
 struct PostLoginRequest: Codable {
     let socialId: String
     let socialType: String
+    let idToken: String
 }

--- a/loleye/loleye/Data/Entities/User/PostRefreshResponse.swift
+++ b/loleye/loleye/Data/Entities/User/PostRefreshResponse.swift
@@ -9,4 +9,5 @@ import Foundation
 
 struct PostRefreshResponse: Codable {
     let accessToken: String
+    let refreshToken: String
 }

--- a/loleye/loleye/Data/Network/API/SummonerAPI.swift
+++ b/loleye/loleye/Data/Network/API/SummonerAPI.swift
@@ -11,6 +11,7 @@ enum SummonerAPI {
     case getSummonerSearch(summonerName: String, tag: String)
     case putSummoner(summoner: Summoner)
     case getSummoner
+    case postSummonerRefresh
 }
 
 extension SummonerAPI: TargetType {
@@ -18,6 +19,7 @@ extension SummonerAPI: TargetType {
         switch self {
         case .getSummonerSearch:            "/app/watch/summoner/search"
         case .putSummoner, .getSummoner:    "/app/watch/summoner"
+        case .postSummonerRefresh:          "/app/watch/summoner/refresh"
         }
     }
     
@@ -25,6 +27,7 @@ extension SummonerAPI: TargetType {
         switch self {
         case .getSummonerSearch, .getSummoner: .get
         case .putSummoner: .put
+        case .postSummonerRefresh: .post
         }
     }
     
@@ -37,7 +40,7 @@ extension SummonerAPI: TargetType {
                 )
         case let .putSummoner(summoner):
                 .requestJSONEncodable(summoner)
-        case .getSummoner:
+        case .getSummoner, .postSummonerRefresh:
                 .requestPlain
         }
     }

--- a/loleye/loleye/Data/Network/API/SummonerAPI.swift
+++ b/loleye/loleye/Data/Network/API/SummonerAPI.swift
@@ -25,9 +25,12 @@ extension SummonerAPI: TargetType {
     
     var method: HTTPMethod {
         switch self {
-        case .getSummonerSearch, .getSummoner: .get
-        case .putSummoner: .put
-        case .postSummonerRefresh: .post
+        case .getSummonerSearch, .getSummoner:
+                .get
+        case .putSummoner:
+                .put
+        case .postSummonerRefresh:
+                .post
         }
     }
     

--- a/loleye/loleye/Data/Network/API/UserAPI.swift
+++ b/loleye/loleye/Data/Network/API/UserAPI.swift
@@ -1,5 +1,5 @@
 //
-//  UseAPI.swift
+//  UserAPI.swift
 //  mejai
 //
 //  Created by 지연 on 12/1/24.
@@ -8,30 +8,36 @@
 import Foundation
 
 enum UserAPI {
-    case postLogin(socialId: String, socialType: String)
+    case postLogin(socialId: String, socialType: String, idToken: String)
     case postRefresh(refreshToken: String)
+    case postDelete
 }
 
 extension UserAPI: TargetType {
     var path: String {
         switch self {
         case .postLogin:    "/app/user/login"
-        case .postRefresh:  "app/user/refresh"
+        case .postRefresh:  "/app/user/refresh"
+        case .postDelete:   "/app/user/delete"
         }
     }
     
     var method: HTTPMethod {
         switch self {
-        case .postLogin, .postRefresh: .post
+        case .postLogin, .postRefresh, .postDelete: .post
         }
     }
     
     var task: Task {
         switch self {
-        case let .postLogin(socialId, socialType):
-                .requestJSONEncodable(PostLoginRequest(socialId: socialId, socialType: socialType))
+        case let .postLogin(socialId, socialType, idToken):
+                .requestJSONEncodable(
+                    PostLoginRequest(socialId: socialId, socialType: socialType, idToken: idToken)
+                )
         case let .postRefresh(refreshToken):
                 .requestJSONEncodable(PostRefreshRequest(refreshToken: refreshToken))
+        case .postDelete:
+                .requestPlain
         }
     }
 }

--- a/loleye/loleye/Data/Network/Service/NetworkService.swift
+++ b/loleye/loleye/Data/Network/Service/NetworkService.swift
@@ -62,7 +62,8 @@ final class NetworkService: NetworkServiceProtocol {
                                 from: target,
                                 try? self.keychainService.retrieve(for: .accessToken)
                             ) else {
-                                return Fail(error: NetworkError.invalidRequest).eraseToAnyPublisher()
+                                return Fail(error: NetworkError.invalidRequest)
+                                    .eraseToAnyPublisher()
                             }
                             return self.session.dataTaskPublisher(for: retryRequest)
                                 .map(\.data) // 튜플에서 Data만 추출
@@ -93,7 +94,6 @@ final class NetworkService: NetworkServiceProtocol {
         }
         
         let target = UserAPI.postRefresh(refreshToken: refreshToken)
-        
         return self.request(target, responseType: PostRefreshResponse.self)
             .handleEvents(receiveOutput: { [weak self] response in
                 // 새로운 토큰 저장

--- a/loleye/loleye/Data/Network/Service/NetworkService.swift
+++ b/loleye/loleye/Data/Network/Service/NetworkService.swift
@@ -11,6 +11,7 @@ import Foundation
 final class NetworkService: NetworkServiceProtocol {
     private let session = URLSession.shared
     private let keychainService: KeychainServiceProtocol
+    private var cancellables = Set<AnyCancellable>()
     
     init(keychainService: KeychainServiceProtocol) {
         self.keychainService = keychainService
@@ -50,34 +51,19 @@ final class NetworkService: NetworkServiceProtocol {
                 }
             }
             .catch { [weak self] error -> AnyPublisher<Data, NetworkError> in
-                print("catch", error)
+                print("catch", error, responseType)
                 guard let self = self else {
                     return Fail(error: NetworkError.unknown(error)).eraseToAnyPublisher()
                 }
                 // 재시도 로직
                 switch error {
                 case NetworkError.tokenExpired:
-                    return self.refreshToken()
-                        .flatMap { _ -> AnyPublisher<Data, NetworkError> in
-                            guard let retryRequest = RequestBuilder.buildURLRequest(
-                                from: target,
-                                try? self.keychainService.retrieve(for: .accessToken)
-                            ) else {
-                                return Fail(error: NetworkError.invalidRequest)
-                                    .eraseToAnyPublisher()
-                            }
-                            return self.session.dataTaskPublisher(for: retryRequest)
-                                .map(\.data) // 튜플에서 Data만 추출
-                                .mapError { NetworkError.unknown($0) }
-                                .eraseToAnyPublisher()
-                        }
-                        .eraseToAnyPublisher()
+                    return self.refreshToken(target, responseType: responseType)
                 default:
                     return Fail(error: NetworkError.unknown(error)).eraseToAnyPublisher()
                 }
             }
-            // 빈 데이터 처리 로직 추가
-            .map { data -> Data in
+            .map { data -> Data in // 빈 데이터 처리 로직 추가
                 if data.isEmpty {
                     return "{}".data(using: .utf8)! // 빈 JSON 객체로 처리
                 }
@@ -96,19 +82,70 @@ final class NetworkService: NetworkServiceProtocol {
             .eraseToAnyPublisher()
     }
     
-    private func refreshToken() -> AnyPublisher<Void, NetworkError> {
+    private func refreshToken<T: Decodable>(
+        _ target: TargetType,
+        responseType: T.Type
+    ) -> AnyPublisher<Data, NetworkError> {
         guard let refreshToken = try? keychainService.retrieve(for: .refreshToken) else {
             return Fail(error: NetworkError.unauthorized).eraseToAnyPublisher()
         }
-        try? keychainService.delete(for: .accessToken)
-        let target = UserAPI.postRefresh(refreshToken: refreshToken)
-        return self.request(target, responseType: PostRefreshResponse.self)
-            .handleEvents(receiveOutput: { [weak self] response in
-                // 새로운 토큰 저장
-                try? self?.keychainService.save(response.accessToken, for: .accessToken)
-                try? self?.keychainService.save(response.refreshToken, for: .refreshToken)
-            })
-            .map { _ in }
+        
+        let refreshTarget = UserAPI.postRefresh(refreshToken: refreshToken)
+        
+        return request(refreshTarget, responseType: PostRefreshResponse.self)
+            .flatMap { [weak self] response -> AnyPublisher<Data, NetworkError> in
+                guard let self = self else {
+                    return Fail(error: NetworkError.unknown(NSError(domain: "Error", code: -1)))
+                        .eraseToAnyPublisher()
+                }
+                do {
+                    print("👩🏻‍💻 새로운 토큰 저장")
+                    try self.keychainService.save(response.accessToken, for: .accessToken)
+                    try self.keychainService.save(response.refreshToken, for: .refreshToken)
+                    
+                    guard let request = RequestBuilder.buildURLRequest(
+                        from: target,
+                        try? keychainService.retrieve(for: .accessToken)
+                    ) else {
+                        return Fail(error: NetworkError.invalidRequest).eraseToAnyPublisher()
+                    }
+                    print("👩🏻‍💻 재발급된 토큰으로 원래 요청 다시 실행")
+                    return session.dataTaskPublisher(for: request)
+                        .tryMap { data, response -> Data in
+                            guard let httpResponse = response as? HTTPURLResponse else {
+                                throw NetworkError.invalidResponse
+                            }
+                            switch httpResponse.statusCode {
+                            case 200...299:
+                                return data
+                            case 401:
+                                throw NetworkError.unauthorized
+                            case 403:
+                                throw NetworkError.tokenExpired
+                            case 400...499:
+                                throw NetworkError.clientError(statusCode: httpResponse.statusCode)
+                            case 500...599:
+                                throw NetworkError.serverError(statusCode: httpResponse.statusCode)
+                            default:
+                                throw NetworkError.unknown(
+                                    NSError(domain: "HTTPError", code: httpResponse.statusCode)
+                                )
+                            }
+                        }
+                        .mapError { error in
+                            if let networkError = error as? NetworkError {
+                                return networkError
+                            } else if error is DecodingError {
+                                return NetworkError.decodingError
+                            } else {
+                                return NetworkError.unknown(error)
+                            }
+                        }
+                        .eraseToAnyPublisher()
+                } catch {
+                    return Fail(error: NetworkError.unknown(error)).eraseToAnyPublisher()
+                }
+            }
             .eraseToAnyPublisher()
     }
 }

--- a/loleye/loleye/Data/Repositories/SummonerRepository.swift
+++ b/loleye/loleye/Data/Repositories/SummonerRepository.swift
@@ -47,4 +47,11 @@ final class SummonerRepository: SummonerRepositoryProtocol {
             .mapError { $0 as Error }
             .eraseToAnyPublisher()
     }
+    
+    func postSummonerRefresh() -> AnyPublisher<PostSummonerRefreshResponse, Error> {
+        let target = SummonerAPI.postSummonerRefresh
+        return networkService.request(target, responseType: PostSummonerRefreshResponse.self)
+            .mapError { $0 as Error }
+            .eraseToAnyPublisher()
+    }
 }

--- a/loleye/loleye/Data/Storage/Keychain/KeychainKey.swift
+++ b/loleye/loleye/Data/Storage/Keychain/KeychainKey.swift
@@ -12,4 +12,5 @@ enum KeychainKey: String {
     case socialId
     case accessToken
     case refreshToken
+    case idToken
 }

--- a/loleye/loleye/Data/Storage/Keychain/KeychainKey.swift
+++ b/loleye/loleye/Data/Storage/Keychain/KeychainKey.swift
@@ -8,6 +8,8 @@
 import Foundation
 
 enum KeychainKey: String {
+    case socialProvider
+    case socialId
     case accessToken
     case refreshToken
 }

--- a/loleye/loleye/Data/Storage/Keychain/KeychainService.swift
+++ b/loleye/loleye/Data/Storage/Keychain/KeychainService.swift
@@ -11,35 +11,33 @@ final class KeychainService: KeychainServiceProtocol {
     
     init() {}
     
-    private func makeQuery(for key: KeychainKey) -> [String: Any] {
-        return [
-            kSecClass as String: kSecClassGenericPassword,
-            kSecAttrAccount as String: key.rawValue
-        ]
-    }
-    
     func save(_ value: String, for key: KeychainKey) throws {
         guard let data = value.data(using: .utf8) else {
             throw KeychainError.stringConversionFailed
         }
         
-        var query = makeQuery(for: key)
-        query[kSecValueData as String] = data
+        try delete(for: key)
+        
+        var query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrAccount as String: key.rawValue,
+            kSecValueData as String: data
+        ]
         
         let status = SecItemAdd(query as CFDictionary, nil)
         
-        if status == errSecDuplicateItem {
-            // 이미 존재하는 경우 업데이트
-            try update(value, for: key)
-        } else if status != errSecSuccess {
+        if status != errSecSuccess {
             throw KeychainError.unexpectedStatus(status)
         }
     }
     
     func retrieve(for key: KeychainKey) throws -> String {
-        var query = makeQuery(for: key)
-        query[kSecReturnData as String] = kCFBooleanTrue
-        query[kSecMatchLimit as String] = kSecMatchLimitOne
+        var query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrAccount as String: key.rawValue,
+            kSecReturnData as String: true,
+            kSecMatchLimit as String: kSecMatchLimitOne
+        ]
         
         var result: AnyObject?
         let status = SecItemCopyMatching(query as CFDictionary, &result)
@@ -61,7 +59,10 @@ final class KeychainService: KeychainServiceProtocol {
     }
     
     func delete(for key: KeychainKey) throws {
-        let query = makeQuery(for: key)
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrAccount as String: key.rawValue
+        ]
         
         let status = SecItemDelete(query as CFDictionary)
         
@@ -70,17 +71,12 @@ final class KeychainService: KeychainServiceProtocol {
         }
     }
     
-    private func update(_ value: String, for key: KeychainKey) throws {
-        guard let data = value.data(using: .utf8) else {
-            throw KeychainError.stringConversionFailed
-        }
+    func clear() throws {
+        let query: [String: Any] = [kSecClass as String: kSecClassGenericPassword]
         
-        let query = makeQuery(for: key)
-        let attributes: [String: Any] = [kSecValueData as String: data]
+        let status = SecItemDelete(query as CFDictionary)
         
-        let status = SecItemUpdate(query as CFDictionary, attributes as CFDictionary)
-        
-        guard status == errSecSuccess else {
+        guard status == errSecSuccess || status == errSecItemNotFound else {
             throw KeychainError.unexpectedStatus(status)
         }
     }

--- a/loleye/loleye/Data/Storage/Keychain/KeychainService.swift
+++ b/loleye/loleye/Data/Storage/Keychain/KeychainService.swift
@@ -8,14 +8,12 @@
 import Foundation
 
 final class KeychainService: KeychainServiceProtocol {
-    private let service = "LOLEYE"
     
     init() {}
     
     private func makeQuery(for key: KeychainKey) -> [String: Any] {
         return [
             kSecClass as String: kSecClassGenericPassword,
-            kSecAttrService as String: service,
             kSecAttrAccount as String: key.rawValue
         ]
     }

--- a/loleye/loleye/Domain/Interfaces/OAuth/Models/OAuthError.swift
+++ b/loleye/loleye/Domain/Interfaces/OAuth/Models/OAuthError.swift
@@ -19,8 +19,9 @@ enum OAuthError: Error {
     // 회원 상태 관련 에러
     case userNotFound          // 회원이 아닌 경우
     case userAlreadyExists     // 이미 가입된 회원인 경우
+    // 키체인 관련 에러
+    case loginInfoSaveFailed   // 키체인 저장 실패
     // 토큰 관련 에러
-    case tokenSaveFailed       // 키체인 저장 실패
     case invalidToken          // 토큰이 유효하지 않음
     case tokenExpired          // 토큰 만료
     // 네트워크 관련 에러
@@ -45,7 +46,7 @@ enum OAuthError: Error {
             return "등록되지 않은 회원입니다."
         case .userAlreadyExists:
             return "이미 가입된 회원입니다."
-        case .tokenSaveFailed:
+        case .loginInfoSaveFailed:
             return "로그인 정보 저장에 실패했습니다."
         case .invalidToken:
             return "유효하지 않은 인증 정보입니다."

--- a/loleye/loleye/Domain/Interfaces/OAuth/OAuthLoginServiceProtocol.swift
+++ b/loleye/loleye/Domain/Interfaces/OAuth/OAuthLoginServiceProtocol.swift
@@ -9,5 +9,5 @@ import Combine
 
 protocol OAuthLoginServiceProtocol {
     var provider: OAuthProvider { get }
-    func login() -> AnyPublisher<String, OAuthError>
+    func login() -> AnyPublisher<(String, String), OAuthError>
 }

--- a/loleye/loleye/Domain/Interfaces/Repositories/SummonerRepositoryProtocol.swift
+++ b/loleye/loleye/Domain/Interfaces/Repositories/SummonerRepositoryProtocol.swift
@@ -19,4 +19,5 @@ protocol SummonerRepositoryProtocol {
         relationship: String
     ) -> AnyPublisher<PutSummonerResponse, Error>
     func getSummonerDetail() -> AnyPublisher<GetSummonerResponse, Error>
+    func postSummonerRefresh() -> AnyPublisher<PostSummonerRefreshResponse, Error>
 }

--- a/loleye/loleye/Domain/Interfaces/Storage/KeychainServiceProtocol.swift
+++ b/loleye/loleye/Domain/Interfaces/Storage/KeychainServiceProtocol.swift
@@ -11,4 +11,5 @@ protocol KeychainServiceProtocol {
     func save(_ value: String, for key: KeychainKey) throws
     func retrieve(for key: KeychainKey) throws -> String
     func delete(for key: KeychainKey) throws
+    func clear() throws
 }

--- a/loleye/loleye/Domain/Models/HomeViewData.swift
+++ b/loleye/loleye/Domain/Models/HomeViewData.swift
@@ -8,6 +8,7 @@
 import Foundation
 
 struct HomeViewData {
+    let lastUpdatedWatchSummoner: String
     let profile: SummonerProfileViewModel
     let rankTiers: [RankTierCellViewModel]
     let todayLogs: [TodayDayLogCellViewModel]

--- a/loleye/loleye/Domain/Models/SummonerDetail/SummonerInfo.swift
+++ b/loleye/loleye/Domain/Models/SummonerDetail/SummonerInfo.swift
@@ -16,4 +16,5 @@ struct SummonerInfo {
     let soloRankIconUrl: String
     let flexRankTier: String
     let flexRankIconUrl: String
+    let lastUpdatedWatchSummoner: String
 }

--- a/loleye/loleye/Domain/UseCases/OAuth/AppleLoginUsecase.swift
+++ b/loleye/loleye/Domain/UseCases/OAuth/AppleLoginUsecase.swift
@@ -47,7 +47,7 @@ extension AppleLoginService: ASAuthorizationControllerDelegate {
             subject.send(completion: .failure(.unknown(NSError(domain: "unexpected error", code: 0))))
             return
         }
-        
+        appleIDCredential.authorizationCode
         subject.send(appleIDCredential.user)
         subject.send(completion: .finished)
     }

--- a/loleye/loleye/Domain/UseCases/OAuth/OAuthUseCase.swift
+++ b/loleye/loleye/Domain/UseCases/OAuth/OAuthUseCase.swift
@@ -61,7 +61,7 @@ final class OAuthUseCase: OAuthLoginUseCaseProtocol {
     private func saveTokens(accessToken: String, refreshToken: String) throws {
         do {
             try keychainService.save(accessToken, for: .accessToken)
-            try keychainService.save(accessToken, for: .refreshToken)
+            try keychainService.save(refreshToken, for: .refreshToken)
         } catch {
             throw OAuthError.tokenSaveFailed
         }

--- a/loleye/loleye/Domain/UseCases/Summoner/GetSummonerDetailUseCase.swift
+++ b/loleye/loleye/Domain/UseCases/Summoner/GetSummonerDetailUseCase.swift
@@ -20,6 +20,7 @@ final class GetSummonerDetailUseCase {
             .map { $0.toDomain() }
             .map { summonerDetail in
                 HomeViewData(
+                    lastUpdatedWatchSummoner: summonerDetail.summoner.lastUpdatedWatchSummoner,
                     profile: .init(
                         relationship: summonerDetail.summoner.relationship.rawValue,
                         name: summonerDetail.summoner.summonerName,

--- a/loleye/loleye/Domain/UseCases/Summoner/PostSummonerRefreshUseCase.swift
+++ b/loleye/loleye/Domain/UseCases/Summoner/PostSummonerRefreshUseCase.swift
@@ -1,0 +1,25 @@
+//
+//  PostSummonerRefreshUseCase.swift
+//  loleye
+//
+//  Created by 지연 on 12/8/24.
+//
+
+import Combine
+import Foundation
+
+final class PostSummonerRefreshUseCase {
+    private let repository: SummonerRepositoryProtocol
+    
+    init(repository: SummonerRepositoryProtocol) {
+        self.repository = repository
+    }
+    
+    func execute() -> AnyPublisher<Void, Error> {
+        repository.postSummonerRefresh()
+            .map { response in
+                print("👩🏻‍💻 PostSummonerRefreshUseCase response:", response)
+            }
+            .eraseToAnyPublisher()
+    }
+}

--- a/loleye/loleye/Domain/UseCases/User/Login/AppleLoginService.swift
+++ b/loleye/loleye/Domain/UseCases/User/Login/AppleLoginService.swift
@@ -1,5 +1,5 @@
 //
-//  AppleLoginUsecase.swift
+//  AppleLoginService.swift
 //  mejai
 //
 //  Created by 지연 on 11/26/24.
@@ -11,11 +11,11 @@ import Foundation
 
 final class AppleLoginService: NSObject, OAuthLoginServiceProtocol {
     let provider: OAuthProvider = .apple
-    private var currentSubject: PassthroughSubject<String, OAuthError>?
+    private var currentSubject: PassthroughSubject<(String, String), OAuthError>?
     
-    func login() -> AnyPublisher<String, OAuthError> {
+    func login() -> AnyPublisher<(String, String), OAuthError> {
         // 새로운 subject 생성
-        let subject = PassthroughSubject<String, OAuthError>()
+        let subject = PassthroughSubject<(String, String), OAuthError>()
         currentSubject = subject
         
         let appleIDProvider = ASAuthorizationAppleIDProvider()
@@ -47,9 +47,12 @@ extension AppleLoginService: ASAuthorizationControllerDelegate {
             subject.send(completion: .failure(.unknown(NSError(domain: "unexpected error", code: 0))))
             return
         }
-        appleIDCredential.authorizationCode
-        subject.send(appleIDCredential.user)
-        subject.send(completion: .finished)
+        if let identityToken = appleIDCredential.identityToken,
+           let idToken = String(data: identityToken, encoding: .utf8) {
+            print("👩🏻‍💻 idToken:", idToken)
+            subject.send((appleIDCredential.user, idToken))
+            subject.send(completion: .finished)
+        }
     }
     
     func authorizationController(

--- a/loleye/loleye/Domain/UseCases/User/Login/OAuthUseCase.swift
+++ b/loleye/loleye/Domain/UseCases/User/Login/OAuthUseCase.swift
@@ -56,6 +56,7 @@ final class OAuthUseCase: OAuthLoginUseCaseProtocol {
                 do {
                     try self.keychainService.save(provider.rawValue, for: .socialProvider)
                     try self.keychainService.save(id, for: .socialId)
+                    try self.keychainService.save(idToken, for: .idToken)
                     try self.keychainService.save(response.accessToken, for: .accessToken)
                     try self.keychainService.save(response.refreshToken, for: .refreshToken)
                     return OAuthResult.success

--- a/loleye/loleye/Domain/UseCases/User/Login/OAuthUseCase.swift
+++ b/loleye/loleye/Domain/UseCases/User/Login/OAuthUseCase.swift
@@ -33,7 +33,7 @@ final class OAuthUseCase: OAuthLoginUseCaseProtocol {
         }
         
         return service.login()
-            .flatMap { self.verifyUser(provider: provider, id: $0) }
+            .flatMap { self.verifyUser(provider: provider, id: $0.0, idToken: $0.1) }
             .catch { error in
                 Just(OAuthResult.failure(error))
             }
@@ -42,10 +42,15 @@ final class OAuthUseCase: OAuthLoginUseCaseProtocol {
     
     private func verifyUser(
         provider: OAuthProvider,
-        id: String
+        id: String,
+        idToken: String
     ) -> AnyPublisher<OAuthResult, OAuthError> {
         print("👩🏻‍💻", provider, id)
-        let target = UserAPI.postLogin(socialId: id, socialType: provider.rawValue)
+        let target = UserAPI.postLogin(
+            socialId: id,
+            socialType: provider.rawValue,
+            idToken: idToken
+        )
         return networkService.request(target, responseType: PostLoginResponse.self)
             .tryMap { response in
                 do {

--- a/loleye/loleye/Domain/UseCases/User/PostDeleteUseCase.swift
+++ b/loleye/loleye/Domain/UseCases/User/PostDeleteUseCase.swift
@@ -1,0 +1,27 @@
+//
+//  PostDeleteUseCase.swift
+//  loleye
+//
+//  Created by 지연 on 12/16/24.
+//
+
+import Combine
+import Foundation
+
+struct EmptyResponse: Decodable {}
+
+final class PostDeleteUseCase {
+    private let networkService: NetworkServiceProtocol
+    
+    init(networkService: NetworkServiceProtocol) {
+        self.networkService = networkService
+    }
+    
+    func execute() -> AnyPublisher<Void, Error> {
+        let target = UserAPI.postDelete
+        return networkService.request(target, responseType: EmptyResponse.self)
+            .map { _ in }
+            .mapError { $0 as Error }
+            .eraseToAnyPublisher()
+    }
+}

--- a/loleye/loleye/Presentation/Scenes/Home/HomeViewController.swift
+++ b/loleye/loleye/Presentation/Scenes/Home/HomeViewController.swift
@@ -33,7 +33,7 @@ final class HomeViewController: BaseViewController<HomeView> {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        configureLargeTitleNavigationBar(title: "mejai", font: .logo, image: .refresh)
+        configureLargeTitleNavigationBar(title: Strings.appName, font: .logo, image: .refresh)
         setupDataSource()
         setupBindings()
         viewModel.send(.fetchSummoner)

--- a/loleye/loleye/Presentation/Scenes/Home/HomeViewController.swift
+++ b/loleye/loleye/Presentation/Scenes/Home/HomeViewController.swift
@@ -34,14 +34,14 @@ final class HomeViewController: BaseViewController<HomeView> {
     override func viewDidLoad() {
         super.viewDidLoad()
         configureLargeTitleNavigationBar(title: "mejai", font: .logo, image: .refresh)
-        configureDataSource()
-        configureBindings()
-        viewModel.send(.fetchSummonerDetail)
+        setupDataSource()
+        setupBindings()
+        viewModel.send(.fetchSummoner)
     }
     
-    // MARK: - Configure Methods
+    // MARK: - Setup Methods
     
-    private func configureDataSource() {
+    private func setupDataSource() {
         rankTierDataSource = UICollectionViewDiffableDataSource<Int, RankTierCellViewModel>(
             collectionView: rankTierCollectionView,
             cellProvider: { (collectionView, indexPath, viewModel) -> UICollectionViewCell? in
@@ -91,16 +91,17 @@ final class HomeViewController: BaseViewController<HomeView> {
         )
     }
     
-    private func configureBindings() {
-        // Action
+    private func setupBindings() {
+        // action
         actionButton?.tapPublisher
             .sink { [weak self] in
-                self?.viewModel.send(.fetchSummonerDetail)
+                self?.viewModel.send(.refresh)
             }
             .store(in: &cancellables)
         
-        // State
+        // state
         viewModel.state.homeViewState
+            .receive(on: RunLoop.main)
             .sink { [weak self] state in
                 guard let self = self else { return }
                 
@@ -114,25 +115,36 @@ final class HomeViewController: BaseViewController<HomeView> {
             }
             .store(in: &cancellables)
         
+        viewModel.state.lastUpated
+            .receive(on: RunLoop.main)
+            .sink { [weak self] text in
+                self?.lastUpdatedLabel.text = text
+            }
+            .store(in: &cancellables)
+        
         viewModel.state.summonerProfileViewModel
+            .receive(on: RunLoop.main)
             .sink { [weak self] viewModel in
                 self?.summonerProfileView.configure(with: viewModel)
             }
             .store(in: &cancellables)
         
         viewModel.state.rankTierCellViewModels
+            .receive(on: RunLoop.main)
             .sink { [weak self] cellViewModels in
                 self?.applySnapshot(with: cellViewModels)
             }
             .store(in: &cancellables)
         
         viewModel.state.todayDayLogCellViewModels
+            .receive(on: RunLoop.main)
             .sink { [weak self] cellViewModels in
                 self?.applySnapshot(with: cellViewModels)
             }
             .store(in: &cancellables)
         
         viewModel.state.todayPlayLogCellViewModels
+            .receive(on: RunLoop.main)
             .sink { [weak self] cellViewModels in
                 guard let self = self else { return }
                 
@@ -145,8 +157,20 @@ final class HomeViewController: BaseViewController<HomeView> {
             .store(in: &cancellables)
         
         viewModel.state.weekPlayLogCellViewModels
+            .receive(on: RunLoop.main)
             .sink { [weak self] cellViewModels in
                 self?.applySnapshot(with: cellViewModels)
+            }
+            .store(in: &cancellables)
+        
+        viewModel.state.refreshLimit
+            .receive(on: RunLoop.main)
+            .sink { [weak self] in
+                self?.showAlert(
+                    title: "데이터 불러오기",
+                    message: "데이터 불러오기는 1시간마다 가능해요\n잠시 후 다시 시도해주세요",
+                    actionText: "확인"
+                )
             }
             .store(in: &cancellables)
     }
@@ -197,6 +221,10 @@ private extension HomeViewController {
     
     var summonerProfileView: SummonerProfileView {
         contentView.summonerProfileView
+    }
+    
+    var lastUpdatedLabel: UILabel {
+        contentView.lastUpdatedLabel
     }
     
     var rankTierCollectionView: UICollectionView {

--- a/loleye/loleye/Presentation/Scenes/Home/ViewModels/HomeViewModel.swift
+++ b/loleye/loleye/Presentation/Scenes/Home/ViewModels/HomeViewModel.swift
@@ -16,16 +16,19 @@ enum HomeViewState {
 
 final class HomeViewModel: ViewModel {
     enum Action {
-        case fetchSummonerDetail
+        case fetchSummoner
+        case refresh
     }
     
     struct State {
         var homeViewState: CurrentValueSubject<HomeViewState, Never>
+        var lastUpated = PassthroughSubject<String, Never>()
         var summonerProfileViewModel: CurrentValueSubject<SummonerProfileViewModel, Never>
         var rankTierCellViewModels: CurrentValueSubject<[RankTierCellViewModel], Never>
         var todayDayLogCellViewModels: CurrentValueSubject<[TodayDayLogCellViewModel], Never>
         var todayPlayLogCellViewModels: CurrentValueSubject<[TodayPlayLogCellViewModel], Never>
         var weekPlayLogCellViewModels: CurrentValueSubject<[WeekPlayLogCellViewModel], Never>
+        var refreshLimit = PassthroughSubject<Void, Never>()
     }
     
     // MARK: - Properties
@@ -35,11 +38,16 @@ final class HomeViewModel: ViewModel {
     private(set) var state: State
     
     private let getSummonerDetailUseCase: GetSummonerDetailUseCase
+    private let postSummonerRefreshUseCase: PostSummonerRefreshUseCase
     
     // MARK: - Init
     
-    init(getSummonerDetailUseCase: GetSummonerDetailUseCase) {
+    init(
+        getSummonerDetailUseCase: GetSummonerDetailUseCase,
+        postSummonerRefreshUseCase: PostSummonerRefreshUseCase
+    ) {
         self.getSummonerDetailUseCase = getSummonerDetailUseCase
+        self.postSummonerRefreshUseCase = postSummonerRefreshUseCase
         self.state = State.initialState
         
         self.actionSubject
@@ -53,27 +61,56 @@ final class HomeViewModel: ViewModel {
     
     private func handleAction(_ action: Action) {
         switch action {
-        case .fetchSummonerDetail:
-            fetchSummonerDetail()
+        case .fetchSummoner:
+            refreshAndFetchDetails(isRefresh: false)
+        case .refresh:
+            refreshAndFetchDetails(isRefresh: true)
         }
     }
     
-    private func fetchSummonerDetail() {
+    private func refreshAndFetchDetails(isRefresh: Bool) {
         state.homeViewState.send(.loading)
         
-        getSummonerDetailUseCase.execute()
-            .receive(on: DispatchQueue.main)
+        postSummonerRefreshUseCase.execute()
             .sink { [weak self] completion in
                 guard let self = self else { return }
                 switch completion {
                 case .finished:
+                    print("👩🏻‍💻 postSummonerRefresh finished")
+                    fetchSummonerDetails()
+                case .failure(let error):
+                    print("👩🏻‍💻 postSummonerRefresh failed:", error)
+                    if case NetworkError.unknown(NetworkError.clientError(statusCode: 429)) = error {
+                        fetchSummonerDetails()
+                        if isRefresh {
+                            state.refreshLimit.send()
+                        }
+                    } else {
+                        state.homeViewState.send(.error)
+                    }
+                }
+            } receiveValue: { _ in }
+            .store(in: &cancellables)
+    }
+    
+    private func fetchSummonerDetails() {
+        getSummonerDetailUseCase.execute()
+            .sink { [weak self] completion in
+                guard let self = self else { return }
+                switch completion {
+                case .finished:
+                    print("👩🏻‍💻 getSummonerDetail finished")
                     state.homeViewState.send(.success)
                 case .failure(let error):
+                    print("👩🏻‍💻 getSummonerDetail failed:", error)
                     state.homeViewState.send(.error)
                     print(error)
                 }
             } receiveValue: { [weak self] viewData in
                 guard let self = self else { return }
+                if let time = extractTime(from: viewData.lastUpdatedWatchSummoner) {
+                    state.lastUpated.send("최근 업데이트: \(time)")
+                }
                 state.summonerProfileViewModel.send(viewData.profile)
                 state.rankTierCellViewModels.send(viewData.rankTiers)
                 state.todayDayLogCellViewModels.send(viewData.todayLogs)
@@ -81,6 +118,21 @@ final class HomeViewModel: ViewModel {
                 state.weekPlayLogCellViewModels.send(viewData.weekPlayLogs)
             }
             .store(in: &cancellables)
+    }
+    
+    private func extractTime(from timestamp: String) -> String? {
+        // DateFormatter 설정
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSS" // 입력 형식
+        
+        // String -> Date 변환
+        guard let date = formatter.date(from: timestamp) else {
+            return nil
+        }
+        
+        // 필요한 시간 형식으로 변환
+        formatter.dateFormat = "HH:mm" // 출력 형식
+        return formatter.string(from: date)
     }
 }
 

--- a/loleye/loleye/Presentation/Scenes/Home/ViewModels/HomeViewModel.swift
+++ b/loleye/loleye/Presentation/Scenes/Home/ViewModels/HomeViewModel.swift
@@ -80,12 +80,14 @@ final class HomeViewModel: ViewModel {
                     fetchSummonerDetails()
                 case .failure(let error):
                     print("👩🏻‍💻 postSummonerRefresh failed:", error)
-                    if case NetworkError.unknown(NetworkError.clientError(statusCode: 429)) = error {
+                    switch error {
+                    case NetworkError.unknown(NetworkError.clientError(statusCode: 429)), // 시간 제한
+                        NetworkError.clientError(statusCode: 429): // 토큰 만료 후 시간 제한
                         fetchSummonerDetails()
                         if isRefresh {
                             state.refreshLimit.send()
                         }
-                    } else {
+                    default:
                         state.homeViewState.send(.error)
                     }
                 }

--- a/loleye/loleye/Presentation/Scenes/Home/Views/HomeView.swift
+++ b/loleye/loleye/Presentation/Scenes/Home/Views/HomeView.swift
@@ -23,6 +23,13 @@ final class HomeView: UIView {
     
     let summonerProfileView = SummonerProfileView()
     
+    let lastUpdatedLabel = {
+        let label = UILabel()
+        label.applyTypography(with: .caption1)
+        label.textColor = .gray04
+        return label
+    }()
+    
     let rankTierView = RankTierView()
     
     let todayView = TodayView()
@@ -41,7 +48,7 @@ final class HomeView: UIView {
     
     override init(frame: CGRect) {
         super.init(frame: frame)
-        configureLayout()
+        setupLayout()
     }
     
     @available(*, unavailable)
@@ -49,9 +56,9 @@ final class HomeView: UIView {
         fatalError("init(coder:) has not been implemented")
     }
     
-    // MARK: - Configure Methods
+    // MARK: - Setup Methods
     
-    private func configureLayout() {
+    private func setupLayout() {
         addSubview(scrollView)
         scrollView.snp.makeConstraints { make in
             make.edges.equalToSuperview()
@@ -67,6 +74,12 @@ final class HomeView: UIView {
         summonerProfileView.snp.makeConstraints { make in
             make.top.equalToSuperview().inset(10)
             make.leading.trailing.equalToSuperview().inset(20)
+        }
+        
+        contentView.addSubview(lastUpdatedLabel)
+        lastUpdatedLabel.snp.makeConstraints { make in
+            make.trailing.equalToSuperview().inset(20)
+            make.centerY.equalTo(summonerProfileView)
         }
         
         contentView.addSubview(rankTierView)

--- a/loleye/loleye/Presentation/Scenes/Home/Views/TodayDayLogCell.swift
+++ b/loleye/loleye/Presentation/Scenes/Home/Views/TodayDayLogCell.swift
@@ -60,6 +60,8 @@ final class TodayDayLogCell: UICollectionViewCell, Reusable {
     
     func configure(with viewModel: TodayDayLogCellViewModel) {
         titleLabel.text = viewModel.cellType.rawValue
-        dataLabel.text = String(viewModel.data)
+        dataLabel.text = viewModel.cellType == .count ?
+        String(viewModel.data) :
+        String(Int(viewModel.data / 60)) // 시간: 초단위 -> 분단위
     }
 }

--- a/loleye/loleye/Presentation/Scenes/Home/Views/TodayPlayLogCell.swift
+++ b/loleye/loleye/Presentation/Scenes/Home/Views/TodayPlayLogCell.swift
@@ -91,7 +91,10 @@ final class TodayPlayLogCell: UICollectionViewCell, Reusable {
     }
     
     func configure(with viewModel: TodayPlayLogCellViewModel) {
-        timeLabel.text = "\(viewModel.startTime) ~ \(viewModel.endTime)"
+        guard let startTime = extractTime(from: viewModel.startTime),
+              let endTime = extractTime(from: viewModel.endTime)
+        else { return }
+        timeLabel.text = "\(startTime) ~ \(endTime)"
         resultLabel.text = viewModel.isWin ? "승리" : "패배"
         resultLabel.textColor = viewModel.isWin ? .primary : .disabled
         upperLine.isHidden = viewModel.isFirst
@@ -104,5 +107,20 @@ private extension TodayPlayLogCell {
         let view = UIView()
         view.backgroundColor = color
         return view
+    }
+    
+    func extractTime(from timestamp: String) -> String? {
+        // DateFormatter 설정
+        let formatter = DateFormatter()
+        formatter.dateFormat = "HH:mm:ss.SS" // 입력 형식
+        
+        // String -> Date 변환
+        guard let date = formatter.date(from: timestamp) else {
+            return nil
+        }
+        
+        // 필요한 시간 형식으로 변환
+        formatter.dateFormat = "HH:mm" // 출력 형식
+        return formatter.string(from: date)
     }
 }

--- a/loleye/loleye/Presentation/Scenes/Home/Views/TodayView.swift
+++ b/loleye/loleye/Presentation/Scenes/Home/Views/TodayView.swift
@@ -18,14 +18,6 @@ final class TodayView: UIView {
         return label
     }()
     
-    private let descriptionLabel = {
-        let label = UILabel()
-        label.text = "00시 00분 기준"
-        label.applyTypography(with: .caption1)
-        label.textColor = .gray04
-        return label
-    }()
-    
     lazy var collectionView = {
         let layout = UICollectionViewFlowLayout()
         layout.minimumInteritemSpacing = 15
@@ -58,12 +50,6 @@ final class TodayView: UIView {
         addSubview(titleLabel)
         titleLabel.snp.makeConstraints { make in
             make.top.leading.equalToSuperview()
-        }
-        
-        addSubview(descriptionLabel)
-        descriptionLabel.snp.makeConstraints { make in
-            make.centerY.equalTo(titleLabel)
-            make.leading.equalTo(titleLabel.snp.trailing).offset(5)
         }
         
         addSubview(collectionView)

--- a/loleye/loleye/Presentation/Scenes/Relationship/ViewModels/RelationshipViewModel.swift
+++ b/loleye/loleye/Presentation/Scenes/Relationship/ViewModels/RelationshipViewModel.swift
@@ -50,7 +50,7 @@ final class RelationshipViewModel: ViewModel {
         case let .relationDidTap(relationship):
             relationDidTap(relationship: relationship)
         case .save:
-            save()
+            registerSummoner()
         }
     }
     
@@ -61,7 +61,7 @@ final class RelationshipViewModel: ViewModel {
         }
     }
     
-    private func save() {
+    private func registerSummoner() {
         let summonerName = summonerSearchData.summonerName
         let tag = summonerSearchData.tag
         guard let relationship = relationship?.rawValue else { return }

--- a/loleye/loleye/Presentation/Scenes/Relationship/ViewModels/RelationshipViewModel.swift
+++ b/loleye/loleye/Presentation/Scenes/Relationship/ViewModels/RelationshipViewModel.swift
@@ -73,10 +73,10 @@ final class RelationshipViewModel: ViewModel {
         .sink { [weak self] completion in
             switch completion {
             case .finished:
-                print("👩🏻‍💻 putSummonerUseCase finished")
+                print("👩🏻‍💻 putSummoner finished")
                 self?.state.fetchResult.send(true)
             case .failure(let error):
-                print("👩🏻‍💻 putSummonerUseCase failed:", error)
+                print("👩🏻‍💻 putSummoner failed:", error)
                 self?.state.fetchResult.send(false)
             }
         } receiveValue: { _ in }

--- a/loleye/loleye/Presentation/Scenes/Settings/SettingsViewController.swift
+++ b/loleye/loleye/Presentation/Scenes/Settings/SettingsViewController.swift
@@ -61,8 +61,8 @@ final class SettingsViewController: BaseViewController<SettingsView> {
                     message: "정말로 탈퇴하시겠어요?\n모든 데이터가 삭제됩니다.",
                     leftActionText: "그만두기",
                     rightActionText: "회원 탈퇴",
-                    rightActionCompletion: {
-                        print("fhrmdkdnt")
+                    rightActionCompletion: { [weak self] in
+                        self?.viewModel.send(.widhdraw)
                     },
                     isRightDangerous: true
                 )
@@ -71,6 +71,7 @@ final class SettingsViewController: BaseViewController<SettingsView> {
         
         // state
         viewModel.state.isActionDone
+            .receive(on: RunLoop.main)
             .sink { [weak self] in
                 self?.delegate?.moveToLogin()
             }

--- a/loleye/loleye/Presentation/Scenes/Settings/SettingsViewController.swift
+++ b/loleye/loleye/Presentation/Scenes/Settings/SettingsViewController.swift
@@ -5,11 +5,60 @@
 //  Created by 지연 on 10/28/24.
 //
 
+import Combine
 import UIKit
 
 final class SettingsViewController: BaseViewController<SettingsView> {
+    private var cancellables = Set<AnyCancellable>()
+    
+    // MARK: - Life cycle
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         configureLargeTitleNavigationBar(title: "설정", font: .heading1)
+        setupBindings()
+    }
+    
+    // MARK: - Setup Methods
+    
+    private func setupBindings() {
+        logoutButton.tapPublisher
+            .sink { [weak self] in
+                self?.showAlert(
+                    title: "로그아웃",
+                    message: "정말로 로그아웃하시겠어요?",
+                    leftActionText: "그만두기",
+                    rightActionText: "로그아웃",
+                    rightActionCompletion: {
+                        print("fhrmdkdnt")
+                    }
+                )
+            }
+            .store(in: &cancellables)
+        
+        withdrawButton.tapPublisher
+            .sink { [weak self] in
+                self?.showAlert(
+                    title: "회원 탈퇴",
+                    message: "정말로 탈퇴하시겠어요?\n모든 데이터가 삭제됩니다.",
+                    leftActionText: "그만두기",
+                    rightActionText: "회원 탈퇴",
+                    rightActionCompletion: {
+                        print("fhrmdkdnt")
+                    },
+                    isRightDangerous: true
+                )
+            }
+            .store(in: &cancellables)
+    }
+}
+
+private extension SettingsViewController {
+    var logoutButton: UIButton {
+        contentView.logoutButton
+    }
+    
+    var withdrawButton: UIButton {
+        contentView.withdrawButton
     }
 }

--- a/loleye/loleye/Presentation/Scenes/Settings/ViewModels/SettingsViewModel.swift
+++ b/loleye/loleye/Presentation/Scenes/Settings/ViewModels/SettingsViewModel.swift
@@ -1,0 +1,66 @@
+//
+//  SettingsViewModel.swift
+//  loleye
+//
+//  Created by 지연 on 12/15/24.
+//
+
+import Combine
+import Foundation
+
+final class SettingsViewModel: ViewModel {
+    enum Action {
+        case logout
+        case widhdraw
+    }
+    
+    struct State {
+        var isActionDone = PassthroughSubject<Void, Never>()
+    }
+    
+    // MARK: - Properties
+    
+    var actionSubject = PassthroughSubject<Action, Never>()
+    var cancellables = Set<AnyCancellable>()
+    var state: State
+    
+    private let keychainService: KeychainServiceProtocol
+    
+    // MARK: - Init
+    
+    init(keychainService: KeychainServiceProtocol) {
+        self.keychainService = keychainService
+        self.state = State()
+        
+        self.actionSubject
+            .sink { [weak self] action in
+                self?.handleAction(action)
+            }
+            .store(in: &cancellables)
+    }
+    
+    // MARK: - Handle Action Methods
+    
+    private func handleAction(_ action: Action) {
+        switch action {
+        case .logout:
+            logout()
+        case .widhdraw:
+            withdraw()
+        }
+    }
+    
+    private func logout() {
+        do {
+            try keychainService.clear()
+            UserDataStorage.shared.isLogin = false
+            state.isActionDone.send()
+        } catch {
+            print("👩🏻‍💻 logout error")
+        }
+    }
+    
+    private func withdraw() {
+        
+    }
+}

--- a/loleye/loleye/Presentation/Scenes/Settings/Views/SettingsView.swift
+++ b/loleye/loleye/Presentation/Scenes/Settings/Views/SettingsView.swift
@@ -8,5 +8,52 @@
 import UIKit
 
 final class SettingsView: UIView {
+    // MARK: - Components
     
+    lazy var logoutButton = createButton(with: "로그아웃")
+    
+    lazy var withdrawButton = createButton(with: "회원 탈퇴")
+    
+    // MARK: - Init
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupLayout()
+    }
+    
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: - Setup Methods
+    
+    private func setupLayout() {
+        addSubview(logoutButton)
+        logoutButton.snp.makeConstraints { make in
+            make.top.equalToSuperview().inset(10)
+            make.leading.trailing.equalToSuperview().inset(20)
+            make.height.equalTo(52)
+        }
+        
+        addSubview(withdrawButton)
+        withdrawButton.snp.makeConstraints { make in
+            make.top.equalTo(logoutButton.snp.bottom)
+            make.leading.trailing.equalToSuperview().inset(20)
+            make.height.equalTo(52)
+        }
+    }
+}
+
+private extension SettingsView {
+    func createButton(with title: String) -> UIButton {
+        let button = UIButton()
+        button.configuration = .plain()
+        var attributedTitle = AttributedString(title)
+        attributedTitle.font = .title2
+        button.configuration?.attributedTitle = attributedTitle
+        button.contentHorizontalAlignment = .leading
+        button.tintColor = .gray09
+        return button
+    }
 }


### PR DESCRIPTION
## ☁️  개요
홈, 설정 기능을 구현합니다.

## 💻 작업 내용
- **소환사 감시 갱신 API 연결**
  - 성공: 소환사 조회 API 요청 (새로운 데이터)
  - 429(시간 제한): 알림창 + 소환사 조회 API 요청 (이전 데이터)
  - 실패: 에러 화면
- **소환사 조회 API 연결**
  - 최근 업데이트 시간,  오늘 기록 데이터 정제
  - 뷰에 업데이트
- **로그인/회원가입 리팩토링**
  - 키체인 로직 리팩토링
  - 추후 기능 추가를 위해 로그인 성공 시 소셜 타입 및 아이디 키체인 저장
  - API 요청에 id token 정보 추가
- **설정 기능 추가**
  - **로그아웃**
    - 액세스 토큰 및 리프레시 토큰 키체인에서 삭제 후 로그인 화면 이동
    - 다시 로그인 시, 온보딩 과정 없이 메인 플로우 진입
  - **회원 탈퇴**
    - 앱 내 저장된 모든 키체인 삭제 후 로그인 화면 이동
    - 다시 회원가입 시, 온보딩 플로우 진입

## 📷 스크린샷

|감시 갱신 결과 성공|감시 갱신 결과 시간 제한|조회 결과 실패|
|-|-|-|
|![IMG_2161](https://github.com/user-attachments/assets/eab63f6a-976f-4083-b73e-e4d73b842145)|![IMG_2160](https://github.com/user-attachments/assets/ec12c493-0200-4ed8-8896-3cee063317c8)|![IMG_2165](https://github.com/user-attachments/assets/3796ccd7-5cd6-43b1-acab-318ac21d1cb3)|

|설정|로그아웃|회원가입|
|-|-|-|
|![IMG_2162](https://github.com/user-attachments/assets/9fddb7c6-fc9b-4a77-8a17-80f668fe8366)|![IMG_2163](https://github.com/user-attachments/assets/7e123883-161e-4285-8f87-53df5bb9dd99)|![IMG_2164](https://github.com/user-attachments/assets/8f2a6106-1056-4978-b337-d2cae8f97498)|

## 💬 참고 내용
- **현재**: 
  - 액세스 토큰 만료 시 액세스 토큰, 리프레시 토큰 모두 재발급
- **나중**: 
  - 액세스 토큰 만료 시 액세스 토큰 재발급
  - 리프레시 토큰 만료 시 로그인 화면으로 이동, 키체인에 저장되어 있는 유저의 소셜 타입, 아이디를 이용하여 자동 로그인 시도

## 🔗 관련 이슈
closes #15 
